### PR TITLE
UI improvements and better macOS support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -250,7 +250,7 @@ with DST, whereas Alaska should be -560 without DST resp -480 with DST)
 _optional, default_: 0 (i.e. GMT)
 
 - `autostart`  
-the boolean value `true`lets the machine start automatically after
+the boolean value `true` lets the machine start automatically after
 building up the Dwarf UI; by default, the Dwarf machine must be started
 manually with the _Start_ button in the toolbar.  
 _optional, default_: `false`
@@ -277,6 +277,13 @@ the following values usually work:
 `xdeNoBlinkWorkAround = 150 : 1987-06-01` for CoPilot 12.3    
 `xdeNoBlinkWorkAround = 150 : 1987-06-01` for Tajo 12.3 + Hacks    
 `xdeNoBlinkWorkAround = 81 : 1995-06-01 ` for Tajo 15.3 (Dawn)
+
+- `showStatusLine`    
+the boolean value `false` hides the status line at the bottom.
+When the status line is hidden, the mouse cursor will display the MP codes (similar to how
+GlobalView and the 6085 implement it) and engine status messages will show up in the
+title bar of the main window.
+_optional, default_: `true`
 
 The following configuration parameters are specific for Draco (6085) machines:
 
@@ -483,15 +490,20 @@ file selection dialog for "inserting" the floppy. If the _R/O_ checkbox is check
 floppy will be loaded in read-only mode, rejecting any attempts to modify the diskette.
 Legacy floppy images are always forced to be loaded in read-only mode.  
 The _Eject_ button removes the floppy, overwriting the floppy image with the new
-content if the floppy was modified.  
+content if the floppy was modified.
+
+On macOS platforms, the button bar is replaced with a native macOS menu bar implementation.
+All of the features of the button bar are available under the Engine (which includes Start
+and Stop) and Floppy (which includes insert/eject floppy, the R/O toggle and the currently
+inserted floppy file name, if any) menu bar items.  
 
 ##### Keyboard
 
 The keyboard mapping can be freely defined through a mapping file, however providing a
 sensible fallback (at least if you have a german keyboard) if no file is specified.
 
-The probably most interesting information is about the special Xerox command keys
-not available on modern PCs, which are mapped to keyboard keys by default resp. additionally by the sample
+Probably the most interesting information is about the special Xerox command keys not
+being available on modern PCs, which are mapped to keyboard keys by default resp. additionally by the sample
 mapping file `kbd_linux_de_DE.map` as follows:
 
 Xerox key|builtin default|kbd_linux_de_DE.map
@@ -520,12 +532,19 @@ Font||F11
 Special||Alt
 Expand||AltGr , Ctrl-Alt
 
+Note that on macOS, due to some issues with using Ctrl as a modifier key, the default modifier key
+is set to Cmd.
+
 ##### Status line
 
 The status line of Dwarfs emulator window shows the current MP code (maintenance panel code)
 at the left, followed by some statistics of the running machine (uptime in seconds, number
 of instructions executed so far, number of disk page reads/writes, number of floppy page
 reads/writes, number of network packets received/sent).
+
+When the status line is hidden, the mouse cursor will display the MP codes (similar to how
+GlobalView and the 6085 implement it) and engine status messages will show up in the
+title bar of the main window.
 
 #### Halting the running system
 
@@ -595,6 +614,12 @@ This does however not affect the normal disk operations, as ViewPoint and the XD
 
 ### Development history
 
+- 2026-03-20 (authored by iblowmymind)
+added `showStatusLine` configuration parameter
+added optional cursor MP code display implementation
+added macOS native menu bar implementation
+set the default modifier key to Cmd on macOS since Ctrl doesn't work
+
 - 2025-01-11    
 bugfix for issue#12: less restrictive label-check for 6085 disks 
 
@@ -606,7 +631,7 @@ added 3 undocumented instructions, apparently introduced by Fuji Xerox (impl. ta
 
 - 2020-11-24    
 added fullscreen support for Duchess (command line option `-fullscreen`)    
-added `autoclose`configuration parameter and `-autoclose` command line parameter to Duchess and Draco
+added `autoclose` configuration parameter and `-autoclose` command line parameter to Duchess and Draco
 
 - 2020-07-05    
 introduced the Draco 6085 emulation as second machine type for the Dwarf Mesa machine kernel    

--- a/src/dev/hawala/dmachine/Draco.java
+++ b/src/dev/hawala/dmachine/Draco.java
@@ -136,8 +136,11 @@ public class Draco {
 	private static int localTimeOffsetMinutes = 0;
 	
 	private static String keyboardMapFile = null;
-	private static int xeroxControlKeyCode = eKeyEventCode.VK_CONTROL.getCode();
+	private static int xeroxControlKeyCode = Utils.IS_MACOS
+			? eKeyEventCode.VK_META.getCode()
+			: eKeyEventCode.VK_CONTROL.getCode();
 	private static boolean resetKeysOnFocusLost = true;
+	private static boolean showStatusLine = true;
 	
 	private static int daysBackInTime = 0;
 	
@@ -246,6 +249,7 @@ public class Draco {
 			xeroxControlKeyCode = Utils.parseKeycode(ctrlKeyCode);
 		}
 		resetKeysOnFocusLost = props.getBoolean("resetKeysOnFocusLost", resetKeysOnFocusLost);
+		showStatusLine = props.getBoolean("showStatusLine", showStatusLine);
 		
 		String mac = props.getString("processorId", null);
 		if (mac == null) {
@@ -578,6 +582,7 @@ public class Draco {
 				int displayWidth = Mem.displayPixelWidth;
 				int displayHeight = Mem.displayPixelHeight;
 				window = new MainUI("Dwarf / Draco 6085", title, displayWidth, displayHeight, true, false, false); // TODO: make resizable a program/configuration parameter?
+				window.setStatusLineVisible(showStatusLine);
 				window.getFrame().setVisible(true);
 				
 				// attach the mouse and keyboard handlers (java-ui => mesa engine) 

--- a/src/dev/hawala/dmachine/Duchess.java
+++ b/src/dev/hawala/dmachine/Duchess.java
@@ -116,11 +116,14 @@ public class Duchess {
 	private static String initialFloppy = null;
 	private static String floppyDirectory = null;
 	private static String keyboardMapFile = null;
-	private static int xeroxControlKeyCode = eKeyEventCode.VK_CONTROL.getCode();
+	private static int xeroxControlKeyCode = Utils.IS_MACOS
+			? eKeyEventCode.VK_META.getCode()
+			: eKeyEventCode.VK_CONTROL.getCode();
 	private static boolean resetKeysOnFocusLost = true;
 	private static String netHubHost = "";
 	private static int netHubPort = 3333;
 	private static int localTimeOffsetMinutes = 0;
+	private static boolean showStatusLine = true;
 	
 	// control flags for the mesa engine
 	private static boolean doStartEngine = false;
@@ -204,6 +207,7 @@ public class Duchess {
 			xeroxControlKeyCode = Utils.parseKeycode(ctrlKeyCode);
 		}
 		resetKeysOnFocusLost = props.getBoolean("resetKeysOnFocusLost", resetKeysOnFocusLost);
+		showStatusLine = props.getBoolean("showStatusLine", showStatusLine);
 		
 		addressBitsReal = Math.max(PrincOpsDefs.MIN_REAL_ADDRESSBITS, Math.min(PrincOpsDefs.MAX_REAL_ADDRESSBITS, addressBitsReal));
 		addressBitsVirtual = Math.max(addressBitsReal, Math.min(PrincOpsDefs.MAX_VIRTUAL_ADDRESSBITS, addressBitsVirtual));
@@ -417,6 +421,7 @@ public class Duchess {
 			try {	
 				// setup the ui main window
 				window = new MainUI("Dwarf / Duchess", title, displayWidth, displayHeight, true, displayTypeColor, runInFullscreen); // TODO: make resizable a program/configuration parameter?
+				window.setStatusLineVisible(showStatusLine);
 				window.getFrame().setVisible(true);
 				
 				// attach the mouse and keyboard handlers (java-ui => mesa engine) 

--- a/src/dev/hawala/dmachine/Utils.java
+++ b/src/dev/hawala/dmachine/Utils.java
@@ -37,10 +37,10 @@ import dev.hawala.dmachine.dwarf.eKeyEventCode;
  */
 public class Utils {
 
-	/** True when running on macOS. */
+	// true when running on macOS, false if otherwise
 	public static final boolean IS_MACOS = System.getProperty("os.name", "").toLowerCase().startsWith("mac");
 
-	
+	// check if the filename identifies an readably file
 	public static boolean isFileOk(String kind, String filename) {
 		if (filename == null) {
 			System.err.printf("Error: no filename given for %s\n", kind);

--- a/src/dev/hawala/dmachine/Utils.java
+++ b/src/dev/hawala/dmachine/Utils.java
@@ -37,8 +37,10 @@ import dev.hawala.dmachine.dwarf.eKeyEventCode;
  */
 public class Utils {
 
+	/** True when running on macOS. */
+	public static final boolean IS_MACOS = System.getProperty("os.name", "").toLowerCase().startsWith("mac");
+
 	
-	// check if the filename identifies an readably file
 	public static boolean isFileOk(String kind, String filename) {
 		if (filename == null) {
 			System.err.printf("Error: no filename given for %s\n", kind);

--- a/src/dev/hawala/dmachine/dwarf/DisplayPane.java
+++ b/src/dev/hawala/dmachine/dwarf/DisplayPane.java
@@ -175,7 +175,8 @@ public abstract class DisplayPane extends JComponent {
 	// content + 1px padding on each side) and 10 pixels tall (8px content + 1px
 	// padding top and bottom).  Rows are stored in visual top-to-bottom order (y=0..9),
 	// each row encoded as 9 bytes (MSB = leftmost pixel).  A '0' bit is an active (black)
-	// pixel; a '1' bit is background (transparent).
+	// pixel; a '1' bit is background (transparent). Taken from the Dawn emulator (mpcode.bmp),
+	// credits to Don Woodward, 2004.
 	private static final byte[] MP_DIGIT_ROWS = {
 		// y=0: top border (all background)
 		(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFC,
@@ -217,8 +218,8 @@ public abstract class DisplayPane extends JComponent {
 	 * <p>
 	 * The two upper digits are placed side-by-side starting at the top-left of the
 	 * cursor image, and the two lower digits are placed slightly inset below them
-	 * (matching the reference layout used by the original Dawn emulator).  Any part
-	 * of a digit tile that falls outside the cursor image boundary is silently clipped.
+	 * (matching the reference layout used by the 6085).  Any part of a digit tile
+	 * that falls outside the cursor image boundary is silently clipped.
 	 * </p>
 	 *
 	 * @param mp the current MP code (0-9999)

--- a/src/dev/hawala/dmachine/dwarf/DisplayPane.java
+++ b/src/dev/hawala/dmachine/dwarf/DisplayPane.java
@@ -170,6 +170,118 @@ public abstract class DisplayPane extends JComponent {
 		}
 	}
 	
+	// MP code cursor support: pixel data for digits 0-9 extracted from a 1-bit BMP.
+	// The source bitmap is 70x10 pixels: 10 digit tiles each 7 pixels wide (5px digit
+	// content + 1px padding on each side) and 10 pixels tall (8px content + 1px
+	// padding top and bottom).  Rows are stored in visual top-to-bottom order (y=0..9),
+	// each row encoded as 9 bytes (MSB = leftmost pixel).  A '0' bit is an active (black)
+	// pixel; a '1' bit is background (transparent).
+	private static final byte[] MP_DIGIT_ROWS = {
+		// y=0: top border (all background)
+		(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFC,
+		// y=1
+		(byte)0xC7, (byte)0xDE, (byte)0x1C, (byte)0x3E, (byte)0x70, (byte)0x78, (byte)0xC1, (byte)0xC7, (byte)0x8C,
+		// y=2
+		(byte)0xBB, (byte)0x9F, (byte)0xEF, (byte)0xDE, (byte)0x77, (byte)0xF7, (byte)0xFD, (byte)0xBB, (byte)0x74,
+		// y=3
+		(byte)0xBB, (byte)0x5F, (byte)0xEF, (byte)0xDD, (byte)0x77, (byte)0xEF, (byte)0xFB, (byte)0xBB, (byte)0x74,
+		// y=4
+		(byte)0xBB, (byte)0xDF, (byte)0xEE, (byte)0x3D, (byte)0x70, (byte)0xE9, (byte)0xFB, (byte)0xC7, (byte)0x64,
+		// y=5
+		(byte)0xBB, (byte)0xDF, (byte)0xDF, (byte)0xDB, (byte)0x7F, (byte)0x66, (byte)0xF7, (byte)0xBB, (byte)0x94,
+		// y=6
+		(byte)0xBB, (byte)0xDF, (byte)0xBF, (byte)0xD8, (byte)0x3F, (byte)0x6E, (byte)0xF7, (byte)0xBB, (byte)0xF4,
+		// y=7
+		(byte)0xBB, (byte)0xDF, (byte)0x7F, (byte)0xDF, (byte)0x7F, (byte)0x6E, (byte)0xEF, (byte)0xBB, (byte)0xEC,
+		// y=8
+		(byte)0xC7, (byte)0xDE, (byte)0x0C, (byte)0x3F, (byte)0x70, (byte)0xF1, (byte)0xEF, (byte)0xC7, (byte)0x1C,
+		// y=9: bottom border (all background)
+		(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFC
+	};
+
+	/**
+	 * Returns {@code true} if the pixel at tile-column {@code x} and tile-row {@code y}
+	 * of the given digit tile (0-9) should be drawn as an opaque black pixel.
+	 */
+	private static boolean isMpDigitPixelActive(int digit, int x, int y) {
+		int globalX   = digit * 7 + x;
+		int byteIndex = y * 9 + globalX / 8;
+		int bitShift  = 7 - (globalX % 8);
+		return ((MP_DIGIT_ROWS[byteIndex] >> bitShift) & 1) == 0; // 0 = black = active
+	}
+
+	/**
+	 * Set the cursor to display the given 4-digit MP code.  This is called whenever
+	 * the MP code is different from 8000 (normal operation) so that the cursor shows
+	 * the current machine-state code instead of the Mesa-defined mouse pointer shape.
+	 * <p>
+	 * The two upper digits are placed side-by-side starting at the top-left of the
+	 * cursor image, and the two lower digits are placed slightly inset below them
+	 * (matching the reference layout used by the original Dawn emulator).  Any part
+	 * of a digit tile that falls outside the cursor image boundary is silently clipped.
+	 * </p>
+	 *
+	 * @param mp the current MP code (0-9999)
+	 */
+	public void setMpCodeCursor(int mp) {
+		int n1 = mp / 1000;
+		int n2 = (mp % 1000) / 100;
+		int n3 = (mp % 100)  / 10;
+		int n4 = mp % 10;
+
+		int imgWidth  = this.cursorBits.getWidth();
+		int imgHeight = this.cursorBits.getHeight();
+
+		DataBufferByte dbb = (DataBufferByte)this.cursorBits.getRaster().getDataBuffer();
+		byte[] cdata = dbb.getData();
+
+		// Clear entire cursor image to transparent (A=0 for TYPE_4BYTE_ABGR)
+		Arrays.fill(cdata, (byte)0);
+
+		// Each digit tile is 7 wide x 10 tall, but rows 0 and 9 are blank padding.
+		// When the cursor image height is < 20 pixels (e.g. 16x16) both rows of digits
+		// won't fit with the full 10-row tiles.  In that case "compact" mode strips the
+		// blank padding rows: upper content occupies py=0..7, lower content py=8..15,
+		// filling the 16px cursor exactly with no overlap and no cutoff (no gap is
+		// possible here; a 1px gap would require 17 rows).
+		// For cursor images ≥ 20 px the full tiles are used; upper content is at py=1..8
+		// and lower starts at lowerDestY=9 so that both tiles share the transparent row
+		// at py=9, giving a 1px visible gap between the two content bands.
+		// Digit tile positions (pixels), matching the reference Dawn layout:
+		//   n1 at (0, 0)   n2 at (7, 0)
+		//   n3 at (2, 8)   n4 at (9, 8)   (compact)
+		//   n3 at (2, 9)   n4 at (9, 9)   (non-compact, 1px transparent gap between rows)
+		boolean compact  = imgHeight < 20;
+		int tileRowStart = compact ? 1 : 0;   // first tile row to render (skip top blank)
+		int tileRowEnd   = compact ? 9 : 10;  // exclusive end (skip bottom blank)
+		int lowerDestY   = compact ? 8 : 9;   // where the lower two digits start
+
+		int[] digits = { n1, n2, n3, n4 };
+		int[] destX  = {  0,  7,  2,  9 };
+		int[] destY  = {  0,  0, lowerDestY, lowerDestY };
+
+		for (int d = 0; d < 4; d++) {
+			int digit = digits[d];
+			int dx    = destX[d];
+			int dy    = destY[d];
+			for (int ty = tileRowStart; ty < tileRowEnd; ty++) {
+				int py = dy + (ty - tileRowStart);
+				if (py >= imgHeight) { continue; }
+				for (int tx = 0; tx < 7; tx++) {
+					int px = dx + tx;
+					if (px >= imgWidth) { continue; }
+					if (isMpDigitPixelActive(digit, tx, ty)) {
+						// TYPE_4BYTE_ABGR byte layout per pixel: [A, B, G, R]
+						// Opaque black: A=255, B=0, G=0, R=0 (B/G/R already 0 from fill)
+						cdata[(py * imgWidth + px) * 4] = (byte)255;
+					}
+				}
+			}
+		}
+
+		this.setCursor(this.tk.createCustomCursor(this.cursorBits, new Point(0, 0), "MP"));
+	}
+
 	/**
 	 * Set a new cursor for the Dwarf screen, possibly re-using an already
 	 * (previously) created cursor having the same display characteristics. 

--- a/src/dev/hawala/dmachine/dwarf/MainUI.java
+++ b/src/dev/hawala/dmachine/dwarf/MainUI.java
@@ -92,16 +92,15 @@ public class MainUI {
 
 	// non-macOS: toolbar controls (null on macOS)
 	private JToolBar toolBar;
+	private DisplayPane displayPanel;
+	private JLabel statusLine;
+	private JCheckBox ckReadOnlyFloppy;
 	private JButton btnStart;
 	private JButton btnStop;
 	private JLabel lblSep1;
 	private JButton btnInsertFloppy;
-	private JCheckBox ckReadOnlyFloppy;
 	private JButton btnEjectFloppy;
 	private JLabel lblFloppyFilename;
-
-	private DisplayPane displayPanel;
-	private JLabel statusLine;
 
 	/**
 	 * Create the application.
@@ -257,7 +256,9 @@ public class MainUI {
 	}
 	
 	/**
-	 * @return {@code true} if the status line label is currently visible.
+	 * Check if the status line is currently visible
+	 * 
+	 * @return {@code true} if the status line is currently visible.
 	 */
 	public boolean isStatusLineVisible() {
 		return this.statusLine != null && this.statusLine.isVisible();
@@ -275,9 +276,10 @@ public class MainUI {
 	}
 	
 	/**
-	 * Update the window title, optionally appending an engine-ended message.
+	 * Update the window title, optionally appending an engine message if available.
+	 * Used when the status line is invisible.
 	 * When {@code suffix} is non-null the title becomes
-	 * {@code "<emulator> Mesa Engine - <title> - <suffix>"};
+	 * {@code "<emulator> Mesa Engine - <title> - <message>"};
 	 * when {@code null} it reverts to the base title.
 	 *
 	 * @param suffix the message to append, or {@code null} to clear it.

--- a/src/dev/hawala/dmachine/dwarf/MainUI.java
+++ b/src/dev/hawala/dmachine/dwarf/MainUI.java
@@ -174,7 +174,7 @@ public class MainUI {
 			
 			menuFloppy.addSeparator();
 			
-			this.miFloppyFilename = new JMenuItem("-");
+			this.miFloppyFilename = new JMenuItem("\u2011"); //macOS doesn't seem to like "-" in menu bar item names
 			this.miFloppyFilename.setEnabled(false);
 			menuFloppy.add(this.miFloppyFilename);
 		} else {
@@ -386,7 +386,7 @@ public class MainUI {
 	public void setFloppyName(String floppyName) {
 		if (Utils.IS_MACOS) {
 			if (floppyName == null || floppyName.length() == 0) {
-				this.miFloppyFilename.setText("-");
+				this.miFloppyFilename.setText("\u2011"); //macOS doesn't seem to like "-" in menu bar item names
 				this.miInsertFloppy.setEnabled(true);
 				this.ckmiReadOnlyFloppy.setEnabled(true);
 				this.miEjectFloppy.setEnabled(false);

--- a/src/dev/hawala/dmachine/dwarf/MainUI.java
+++ b/src/dev/hawala/dmachine/dwarf/MainUI.java
@@ -39,10 +39,16 @@ import java.awt.event.WindowEvent;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
+
+import dev.hawala.dmachine.Utils;
 
 /**
  * Main UI frame for a Dwarf machine.
@@ -50,7 +56,14 @@ import javax.swing.SwingConstants;
  * @author Dr. Hans-Walter Latz / Berlin (2017)
  */
 public class MainUI {
-	
+
+	static {
+		// Must be set before any AWT/Swing components are created to take effect on macOS.
+		if (Utils.IS_MACOS) {
+			System.setProperty("apple.laf.useScreenMenuBar", "true");
+		}
+	}
+
 	/**
 	 * possible states of the mesa engine, controlling the 'enabled' states of the
 	 * Start/Stop buttons.
@@ -63,20 +76,32 @@ public class MainUI {
 	// the top-level frame for the UI
 	private JFrame frmDwarfMesaEngine;
 	
+	private final String emulatorName;
 	private final String title;
 	private final int displayWidth;
 	private final int displayHeight;
 	
+	// macOS: menu-bar controls (null on non-macOS)
+	private JMenuBar menuBar;
+	private JMenuItem miStart;
+	private JMenuItem miStop;
+	private JMenuItem miInsertFloppy;
+	private JCheckBoxMenuItem ckmiReadOnlyFloppy;
+	private JMenuItem miEjectFloppy;
+	private JMenuItem miFloppyFilename;
+
+	// non-macOS: toolbar controls (null on macOS)
 	private JToolBar toolBar;
-	private DisplayPane displayPanel;
-	private JLabel statusLine;
-	private JCheckBox ckReadOnlyFloppy;
 	private JButton btnStart;
 	private JButton btnStop;
 	private JLabel lblSep1;
 	private JButton btnInsertFloppy;
+	private JCheckBox ckReadOnlyFloppy;
 	private JButton btnEjectFloppy;
 	private JLabel lblFloppyFilename;
+
+	private DisplayPane displayPanel;
+	private JLabel statusLine;
 
 	/**
 	 * Create the application.
@@ -90,6 +115,7 @@ public class MainUI {
 	 * @param runInFullscreen let it be a fullscreen application?
 	 */
 	public MainUI(String emulatorName, String title, int displayWidth, int displayHeight, boolean resizable, boolean colorDisplay, boolean runInFullscreen) {
+		this.emulatorName = emulatorName;
 		this.title = title;
 		this.displayWidth = displayWidth;
 		this.displayHeight = displayHeight;
@@ -114,39 +140,80 @@ public class MainUI {
 			}
 		}
 		
-		this.toolBar = new JToolBar();
-		this.toolBar.setFloatable(false);
-		this.toolBar.setOrientation(SwingConstants.HORIZONTAL);
-		this.frmDwarfMesaEngine.getContentPane().add(this.toolBar, BorderLayout.NORTH);
-		
-		this.btnStart = new JButton("Start");
-		this.btnStart.setToolTipText("boot the mesa engine");
-		this.toolBar.add(btnStart);
-		
-		this.btnStop = new JButton("Stop");
-		this.btnStop.setToolTipText("stop the running engine and persist disk(s) modifications");
-		this.toolBar.add(btnStop);
-		
-		this.lblSep1 = new JLabel("   Floppy: ");
-		this.toolBar.add(lblSep1);
-		
-		this.btnInsertFloppy = new JButton("Insert");
-		this.btnInsertFloppy.setToolTipText("insert a floppy disk image (*.img), possibly in read-only mode\nif the R/O checkbox is checked ");
-		this.toolBar.add(btnInsertFloppy);
-		
-		this.ckReadOnlyFloppy = new JCheckBox("R/O");
-		this.ckReadOnlyFloppy.setToolTipText("if checked: force the next floppy inserted to be read-only");
-		this.toolBar.add(ckReadOnlyFloppy);
-		
-		this.btnEjectFloppy = new JButton("Eject");
-		this.btnEjectFloppy.setToolTipText("eject the floppy currently inserted");
-		this.toolBar.add(btnEjectFloppy);
-		
-		this.toolBar.add(new JLabel(" "));
-		
-		this.lblFloppyFilename = new JLabel("...");
-		this.lblFloppyFilename.setFont(new Font("Dialog", Font.PLAIN, 12));
-		this.toolBar.add(lblFloppyFilename);
+		if (Utils.IS_MACOS) {
+			// macOS: use a native menu bar instead of a toolbar
+			this.menuBar = new JMenuBar();
+			this.frmDwarfMesaEngine.setJMenuBar(this.menuBar);
+			
+			// Engine menu
+			JMenu menuEngine = new JMenu("Engine");
+			this.menuBar.add(menuEngine);
+			
+			this.miStart = new JMenuItem("Start");
+			this.miStart.setToolTipText("boot the mesa engine");
+			menuEngine.add(this.miStart);
+			
+			this.miStop = new JMenuItem("Stop");
+			this.miStop.setToolTipText("stop the running engine and persist disk(s) modifications");
+			menuEngine.add(this.miStop);
+			
+			// Floppy menu
+			JMenu menuFloppy = new JMenu("Floppy");
+			this.menuBar.add(menuFloppy);
+			
+			this.miInsertFloppy = new JMenuItem("Insert Floppy...");
+			this.miInsertFloppy.setToolTipText("insert a floppy disk image (*.img), possibly in read-only mode if R/O is checked");
+			menuFloppy.add(this.miInsertFloppy);
+			
+			this.ckmiReadOnlyFloppy = new JCheckBoxMenuItem("Read-Only");
+			this.ckmiReadOnlyFloppy.setToolTipText("if checked: force the next floppy inserted to be read-only");
+			menuFloppy.add(this.ckmiReadOnlyFloppy);
+			
+			this.miEjectFloppy = new JMenuItem("Eject Floppy");
+			this.miEjectFloppy.setToolTipText("eject the floppy currently inserted");
+			menuFloppy.add(this.miEjectFloppy);
+			
+			menuFloppy.addSeparator();
+			
+			this.miFloppyFilename = new JMenuItem("-");
+			this.miFloppyFilename.setEnabled(false);
+			menuFloppy.add(this.miFloppyFilename);
+		} else {
+			// Windows / Linux: use the original toolbar
+			this.toolBar = new JToolBar();
+			this.toolBar.setFloatable(false);
+			this.toolBar.setOrientation(SwingConstants.HORIZONTAL);
+			this.frmDwarfMesaEngine.getContentPane().add(this.toolBar, BorderLayout.NORTH);
+			
+			this.btnStart = new JButton("Start");
+			this.btnStart.setToolTipText("boot the mesa engine");
+			this.toolBar.add(this.btnStart);
+			
+			this.btnStop = new JButton("Stop");
+			this.btnStop.setToolTipText("stop the running engine and persist disk(s) modifications");
+			this.toolBar.add(this.btnStop);
+			
+			this.lblSep1 = new JLabel("   Floppy: ");
+			this.toolBar.add(this.lblSep1);
+			
+			this.btnInsertFloppy = new JButton("Insert");
+			this.btnInsertFloppy.setToolTipText("insert a floppy disk image (*.img), possibly in read-only mode\nif the R/O checkbox is checked ");
+			this.toolBar.add(this.btnInsertFloppy);
+			
+			this.ckReadOnlyFloppy = new JCheckBox("R/O");
+			this.ckReadOnlyFloppy.setToolTipText("if checked: force the next floppy inserted to be read-only");
+			this.toolBar.add(this.ckReadOnlyFloppy);
+			
+			this.btnEjectFloppy = new JButton("Eject");
+			this.btnEjectFloppy.setToolTipText("eject the floppy currently inserted");
+			this.toolBar.add(this.btnEjectFloppy);
+			
+			this.toolBar.add(new JLabel(" "));
+			
+			this.lblFloppyFilename = new JLabel("...");
+			this.lblFloppyFilename.setFont(new Font("Dialog", Font.PLAIN, 12));
+			this.toolBar.add(this.lblFloppyFilename);
+		}
 		
 		this.displayPanel = (colorDisplay)
 				? new Display8BitColorPane(this.displayWidth, this.displayHeight)
@@ -190,65 +257,120 @@ public class MainUI {
 	}
 	
 	/**
+	 * @return {@code true} if the status line label is currently visible.
+	 */
+	public boolean isStatusLineVisible() {
+		return this.statusLine != null && this.statusLine.isVisible();
+	}
+
+	/**
+	 * Set the visibility of the status line.
+	 *
+	 * @param visible {@code true} to show the status line, {@code false} to hide it.
+	 */
+	public void setStatusLineVisible(boolean visible) {
+		if (this.statusLine == null) { return; }
+		this.statusLine.setVisible(visible);
+		this.frmDwarfMesaEngine.pack();
+	}
+	
+	/**
+	 * Update the window title, optionally appending an engine-ended message.
+	 * When {@code suffix} is non-null the title becomes
+	 * {@code "<emulator> Mesa Engine - <title> - <suffix>"};
+	 * when {@code null} it reverts to the base title.
+	 *
+	 * @param suffix the message to append, or {@code null} to clear it.
+	 */
+	public void setTitleSuffix(String suffix) {
+		String baseTitle = this.emulatorName + " Mesa Engine - " + this.title;
+		String trimmed = (suffix != null) ? suffix.trim() : "";
+		this.frmDwarfMesaEngine.setTitle(
+				!trimmed.isEmpty() ? baseTitle + " - " + trimmed : baseTitle);
+	}
+	
+	/**
 	 * Change the running state for setting the 'enabled' states of the
 	 * Start/Stop buttons.
 	 * 
 	 * @param state the new state of the mesa engine
 	 */
 	public void setRunningState(RunningState state) {
-		switch(state) {
-		case notRunning:
-			this.btnStart.setEnabled(true);
-			this.btnStop.setEnabled(false);
-			return;
-		case running:
-			this.btnStart.setEnabled(false);
-			this.btnStop.setEnabled(true);
-			return;
-		case stopped:
-			this.btnStart.setEnabled(false);
-			this.btnStop.setEnabled(false);
-			return;
+		if (Utils.IS_MACOS) {
+			switch(state) {
+			case notRunning:
+				this.miStart.setEnabled(true);
+				this.miStop.setEnabled(false);
+				return;
+			case running:
+				this.miStart.setEnabled(false);
+				this.miStop.setEnabled(true);
+				return;
+			case stopped:
+				this.miStart.setEnabled(false);
+				this.miStop.setEnabled(false);
+				return;
+			}
+		} else {
+			switch(state) {
+			case notRunning:
+				this.btnStart.setEnabled(true);
+				this.btnStop.setEnabled(false);
+				return;
+			case running:
+				this.btnStart.setEnabled(false);
+				this.btnStop.setEnabled(true);
+				return;
+			case stopped:
+				this.btnStart.setEnabled(false);
+				this.btnStop.setEnabled(false);
+				return;
+			}
 		}
 	}
 	
 	/**
-	 * Add an action callback to the 'Start' button.
+	 * Add an action callback to the 'Start' control.
 	 * @param action callback instance.
 	 */
 	public void addStartAction(ActionListener action) {
-		this.btnStart.addActionListener(action);
+		if (Utils.IS_MACOS) { this.miStart.addActionListener(action); }
+		else { this.btnStart.addActionListener(action); }
 	}
 	
 	/**
-	 * Add an action callback to the 'Stop' button.
+	 * Add an action callback to the 'Stop' control.
 	 * @param action callback instance.
 	 */
 	public void addStopAction(ActionListener action) {
-		this.btnStop.addActionListener(action);
+		if (Utils.IS_MACOS) { this.miStop.addActionListener(action); }
+		else { this.btnStop.addActionListener(action); }
 	}
 	
 	/**
-	 * Add an action callback to the 'Insert' (floppy) button.
+	 * Add an action callback to the 'Insert' (floppy) control.
 	 * @param action callback instance.
 	 */
 	public void addInsertFloppyAction(ActionListener action) {
-		this.btnInsertFloppy.addActionListener(action);
+		if (Utils.IS_MACOS) { this.miInsertFloppy.addActionListener(action); }
+		else { this.btnInsertFloppy.addActionListener(action); }
 	}
 	
 	/**
-	 * Add an action callback to the 'Eject' (floppy) button.
+	 * Add an action callback to the 'Eject' (floppy) control.
 	 * @param action callback instance.
 	 */
 	public void addEjectFloppyAction(ActionListener action) {
-		this.btnEjectFloppy.addActionListener(action);
+		if (Utils.IS_MACOS) { this.miEjectFloppy.addActionListener(action); }
+		else { this.btnEjectFloppy.addActionListener(action); }
 	}
 	
 	/**
-	 * Get the state of the (floppy) 'R/O' checkbox.
-	 * @return checked {@code true} if the 'R/O' checkbox is checked.
+	 * Get the state of the (floppy) 'R/O' control.
+	 * @return {@code true} if the 'R/O' control is checked/selected.
 	 */
 	public boolean writeProtectFloppy() {
+		if (Utils.IS_MACOS) { return this.ckmiReadOnlyFloppy.isSelected(); }
 		return this.ckReadOnlyFloppy.isSelected();
 	}
 	
@@ -260,16 +382,30 @@ public class MainUI {
 	 *   passing a non-empty floppy name will invert these states.
 	 */
 	public void setFloppyName(String floppyName) {
-		if (floppyName == null || floppyName.length() == 0) {
-			this.lblFloppyFilename.setText("-");
-			this.btnInsertFloppy.setEnabled(true);
-			this.ckReadOnlyFloppy.setEnabled(true);
-			this.btnEjectFloppy.setEnabled(false);
+		if (Utils.IS_MACOS) {
+			if (floppyName == null || floppyName.length() == 0) {
+				this.miFloppyFilename.setText("-");
+				this.miInsertFloppy.setEnabled(true);
+				this.ckmiReadOnlyFloppy.setEnabled(true);
+				this.miEjectFloppy.setEnabled(false);
+			} else {
+				this.miFloppyFilename.setText(floppyName);
+				this.miInsertFloppy.setEnabled(false);
+				this.ckmiReadOnlyFloppy.setEnabled(false);
+				this.miEjectFloppy.setEnabled(true);
+			}
 		} else {
-			this.lblFloppyFilename.setText(floppyName);
-			this.btnInsertFloppy.setEnabled(false);
-			this.ckReadOnlyFloppy.setEnabled(false);
-			this.btnEjectFloppy.setEnabled(true);
+			if (floppyName == null || floppyName.length() == 0) {
+				this.lblFloppyFilename.setText("-");
+				this.btnInsertFloppy.setEnabled(true);
+				this.ckReadOnlyFloppy.setEnabled(true);
+				this.btnEjectFloppy.setEnabled(false);
+			} else {
+				this.lblFloppyFilename.setText(floppyName);
+				this.btnInsertFloppy.setEnabled(false);
+				this.ckReadOnlyFloppy.setEnabled(false);
+				this.btnEjectFloppy.setEnabled(true);
+			}
 		}
 	}
 	
@@ -286,19 +422,29 @@ public class MainUI {
 		JFrame frame = new JFrame("Fullscreen");
 		frame.getContentPane().setLayout(new BorderLayout(2, 2));
 		
-		JToolBar toolBar = new JToolBar();
-		toolBar.setFloatable(false);
-		toolBar.setOrientation(SwingConstants.HORIZONTAL);
-		frame.getContentPane().add(toolBar, BorderLayout.NORTH);
-		
-		JButton btnStart = new JButton("Start");
-		btnStart.setToolTipText("boot the mesa engine");
-		toolBar.add(btnStart);
-		
-		JButton btnStop = new JButton("Stop");
-		btnStop.setToolTipText("stop the running engine and persist disk(s) modifications");
-		toolBar.add(btnStop);
-		btnStop.addActionListener(e -> { frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING)); System.exit(0); });
+		if (Utils.IS_MACOS) {
+			JMenuBar menuBar = new JMenuBar();
+			frame.setJMenuBar(menuBar);
+			JMenu menuEngine = new JMenu("Engine");
+			menuBar.add(menuEngine);
+			JMenuItem miStop = new JMenuItem("Stop");
+			miStop.addActionListener(e -> { frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING)); System.exit(0); });
+			menuEngine.add(miStop);
+		} else {
+			JToolBar toolBar = new JToolBar();
+			toolBar.setFloatable(false);
+			toolBar.setOrientation(SwingConstants.HORIZONTAL);
+			frame.getContentPane().add(toolBar, BorderLayout.NORTH);
+			
+			JButton btnStart = new JButton("Start");
+			btnStart.setToolTipText("boot the mesa engine");
+			toolBar.add(btnStart);
+			
+			JButton btnStop = new JButton("Stop");
+			btnStop.setToolTipText("stop the running engine and persist disk(s) modifications");
+			toolBar.add(btnStop);
+			btnStop.addActionListener(e -> { frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING)); System.exit(0); });
+		}
 		
 		JLabel label = new JLabel("", JLabel.CENTER);
 		label.setText("This is not yet in fullscreen mode!");

--- a/src/dev/hawala/dmachine/dwarf/UiRefresher.java
+++ b/src/dev/hawala/dmachine/dwarf/UiRefresher.java
@@ -210,8 +210,7 @@ public class UiRefresher implements ActionListener, iMesaMachineDataAccessor, Po
 				this.newStatusLine = null;
 			}
 			
-			// if there is a stop message from the mesa engine: show in title bar when the
-			// status line is hidden, otherwise let it alternate with the last status line
+			// if there is a stop message from the mesa engine: show in title bar when the status line is hidden, otherwise let it alternate with the last status line
 			if (this.engineEndedMessage != null) {
 				if (!this.mainWindow.isStatusLineVisible()) {
 					// status bar hidden: append the message to the window title

--- a/src/dev/hawala/dmachine/dwarf/UiRefresher.java
+++ b/src/dev/hawala/dmachine/dwarf/UiRefresher.java
@@ -72,6 +72,18 @@ public class UiRefresher implements ActionListener, iMesaMachineDataAccessor, Po
 	private short[] newCursorBitmap = null;
 	private int newCursorHotspotX = 0;
 	private int newCursorHotspotY = 0;
+
+	// last cursor shape sent by the Mesa engine, kept so it can be restored when MP returns to 8000
+	private short[] lastNormalCursorBitmap = null;
+	private int lastNormalCursorHotspotX = 0;
+	private int lastNormalCursorHotspotY = 0;
+
+	// current MP code and a flag indicating the cursor should be updated to show the MP code
+	private int currentMp = 8000;
+	private boolean mpCursorDirty = false;
+	// system-millisecond deadline after which the cursor reverts to normal once MP returns to 8000
+	private long mpLingerEndTime = 0;
+	private static final long MP_CURSOR_LINGER_MS = 3000; // 3 s linger after MP returns to 8000
 	
 	// the pending next status line to set on the Java ui (reset to null when set in the ui) 
 	private String newStatusLine = null;
@@ -156,10 +168,39 @@ public class UiRefresher implements ActionListener, iMesaMachineDataAccessor, Po
 				this.doRepaint = false;
 			}
 			
-			// set the new cursor if a new one was given
-			if (this.newCursorBitmap != null) {
-				this.mainWindow.getDisplayPane().setCursor(this.newCursorBitmap, this.newCursorHotspotX, this.newCursorHotspotY);
-				this.newCursorBitmap = null;
+			// set the cursor: MP code cursor only when the status bar is hidden;
+			// when the status bar is visible, use normal Mesa cursor handling
+			if (!this.mainWindow.isStatusLineVisible()) {
+				// status bar hidden: show MP code on cursor
+				if (this.mpCursorDirty) {
+					this.mainWindow.getDisplayPane().setMpCodeCursor(this.currentMp);
+					this.mpCursorDirty = false;
+					this.newCursorBitmap = null;
+				} else if (this.mpLingerEndTime > 0) {
+					// MP is back to 8000 but still within the linger window; once it expires
+					// immediately restore the last Mesa-defined cursor.
+					if (System.currentTimeMillis() >= this.mpLingerEndTime) {
+						this.mpLingerEndTime = 0;
+						if (this.lastNormalCursorBitmap != null) {
+							this.mainWindow.getDisplayPane().setCursor(
+									this.lastNormalCursorBitmap,
+									this.lastNormalCursorHotspotX,
+									this.lastNormalCursorHotspotY);
+						}
+						this.newCursorBitmap = null;
+					}
+				} else if (this.newCursorBitmap != null) {
+					this.mainWindow.getDisplayPane().setCursor(this.newCursorBitmap, this.newCursorHotspotX, this.newCursorHotspotY);
+					this.newCursorBitmap = null;
+				}
+			} else {
+				// status bar visible: clear any pending MP cursor state and apply normal cursor
+				this.mpCursorDirty = false;
+				this.mpLingerEndTime = 0;
+				if (this.newCursorBitmap != null) {
+					this.mainWindow.getDisplayPane().setCursor(this.newCursorBitmap, this.newCursorHotspotX, this.newCursorHotspotY);
+					this.newCursorBitmap = null;
+				}
 			}
 			
 			// update the status line if there is a new one
@@ -169,17 +210,25 @@ public class UiRefresher implements ActionListener, iMesaMachineDataAccessor, Po
 				this.newStatusLine = null;
 			}
 			
-			// if there is a stop message from the mesa engine: let it alternate with the last status line
+			// if there is a stop message from the mesa engine: show in title bar when the
+			// status line is hidden, otherwise let it alternate with the last status line
 			if (this.engineEndedMessage != null) {
-				long now = System.currentTimeMillis();
-				if ((now - this.lastStatusLineSwitch) > STATUS_SWITCH_INTERVAL) {
-					if (this.statusLineIsEndedMessage) {
-						this.mainWindow.setStatusLine(this.lastStatusLine);
-					} else {
-						this.mainWindow.setStatusLine(this.engineEndedMessage);
+				if (!this.mainWindow.isStatusLineVisible()) {
+					// status bar hidden: append the message to the window title
+					this.mainWindow.setTitleSuffix(this.engineEndedMessage);
+				} else {
+					// status bar visible: clear any title suffix and alternate the status line
+					this.mainWindow.setTitleSuffix(null);
+					long now = System.currentTimeMillis();
+					if ((now - this.lastStatusLineSwitch) > STATUS_SWITCH_INTERVAL) {
+						if (this.statusLineIsEndedMessage) {
+							this.mainWindow.setStatusLine(this.lastStatusLine);
+						} else {
+							this.mainWindow.setStatusLine(this.engineEndedMessage);
+						}
+						this.statusLineIsEndedMessage = !this.statusLineIsEndedMessage;
+						this.lastStatusLineSwitch = now;
 					}
-					this.statusLineIsEndedMessage = !this.statusLineIsEndedMessage;
-					this.lastStatusLineSwitch = now;
 				}
 			}
 		}
@@ -201,9 +250,21 @@ public class UiRefresher implements ActionListener, iMesaMachineDataAccessor, Po
 	@Override
 	public void acceptMP(int mp) {
 		synchronized(this) {
+			int prevMp = this.currentMp;
+			this.currentMp = mp;
 			this.statusMpPart = String.format(" %04d ", mp);
 			this.newStatusLine = this.statusMpPart + this.statusStatsPart;
-		}	
+			if (mp != 8000) {
+				// show the MP code in the cursor instead of the normal mouse pointer
+				this.mpCursorDirty = true;
+				this.mpLingerEndTime = 0; // cancel any pending linger
+			} else if (prevMp != 8000) {
+				// MP returned to normal operation: show 8000 in the cursor, then linger
+				// before restoring the Mesa-defined cursor
+				this.mpCursorDirty = true; // trigger one render of the 8000 cursor
+				this.mpLingerEndTime = System.currentTimeMillis() + MP_CURSOR_LINGER_MS;
+			}
+		}
 	}
 
 	// invoked by the mesa engine at more or less regular intervals
@@ -254,9 +315,14 @@ public class UiRefresher implements ActionListener, iMesaMachineDataAccessor, Po
 	@Override
 	public void setPointerBitmap(short[] bitmap, int hotspotX, int hotspotY) {
 		synchronized(this) {
-			this.newCursorBitmap = bitmap;
-			this.newCursorHotspotX = hotspotX;
-			this.newCursorHotspotY = hotspotY;
+			this.lastNormalCursorBitmap = bitmap;
+			this.lastNormalCursorHotspotX = hotspotX;
+			this.lastNormalCursorHotspotY = hotspotY;
+			if (this.currentMp == 8000 && this.mpLingerEndTime == 0) {
+				this.newCursorBitmap = bitmap;
+				this.newCursorHotspotX = hotspotX;
+				this.newCursorHotspotY = hotspotY;
+			}
 		}
 	}
 	


### PR DESCRIPTION
This PR implements a couple changes related to UI/UX and better macOS integration.

## Changes
- Adds a property, `showStatusLine` to show/hide the status line at the bottom. Defaults to true. When set to false, the cursor also shows the MP codes like GVWIN or 6085 machines do. (I know you've stated that you don't like this behavior, so I've made sure it's opt-in) Also when set to false, the title bar will show engine messages if there are any.
- On macOS, removes the button bar at the top and moves all of the actions to the macOS menu bar as having an application menu bar is redundant UX and wastes space when a global menu bar is already available at the top. (Windows and Linux retain original behavior and still have the button bar) Combined with the showStatusLine property, this allows you to have a fullscreen emulator window!
- On macOS, the modifier key is now set to Cmd by default, as there seems to be an issue parsing the Control key as a modifier, as documented by me. (And another user in the issues, if my memory serves me correct?) (This behavior was already available with the xeroxControlKeyCode property, but now it's the default to reduce friction and confusion) 

## Caveats
- Tested with Java 25 (but should work in Java 8)
- Not tested outside macOS yet

## TODO
- [x] Fix the empty floppy image message ("-") showing on the macOS menu bar too, as it's broken right now
- [ ] ~~Figure out a way to add a 1 pixel of gap to the cursor MP code between the top row and the bottom row of numbers because I think they look a little squished right now~~
- [x] Update README.md ~~with newer screenshots (don't think it's really necessary)~~ and the new features
- [ ] Update dist.zip (possibly remove it to be replaced by GitHub releases? but that's something out of my control)

## Disclaimer
The MP cursor code part was written with the assistance of AI as I struggled with implementing that on my own but I've personally reviewed the generated code and everything seems fine to me.